### PR TITLE
Add support to print the predictions and to use mean_value when mean_file is not supplied

### DIFF
--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -257,10 +257,10 @@ class Transformer:
                 raise ValueError('Mean shape invalid')
             if ms != self.inputs[in_][1:]:
                 print(self.inputs[in_])
-    		    in_shape = self.inputs[in_][1:]
-    		    m_min, m_max = mean.min(), mean.max()
-    		    normal_mean = (mean - m_min) / (m_max - m_min)
-    		    mean = resize_image(normal_mean.transpose((1,2,0)),
+    		in_shape = self.inputs[in_][1:]
+    		m_min, m_max = mean.min(), mean.max()
+    		normal_mean = (mean - m_min) / (m_max - m_min)
+    		mean = resize_image(normal_mean.transpose((1,2,0)),
                         in_shape[1:]).transpose((2,0,1)) * \
                         (m_max - m_min) + m_min
                 #raise ValueError('Mean shape incompatible with input shape.')

--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -256,7 +256,14 @@ class Transformer:
             if len(ms) != 3:
                 raise ValueError('Mean shape invalid')
             if ms != self.inputs[in_][1:]:
-                raise ValueError('Mean shape incompatible with input shape.')
+                print(self.inputs[in_])
+    		 in_shape = self.inputs[in_][1:]
+    		 m_min, m_max = mean.min(), mean.max()
+    		 normal_mean = (mean - m_min) / (m_max - m_min)
+    		 mean = resize_image(normal_mean.transpose((1,2,0)),
+                        in_shape[1:]).transpose((2,0,1)) * \
+                        (m_max - m_min) + m_min
+                #raise ValueError('Mean shape incompatible with input shape.')
         self.mean[in_] = mean
 
     def set_input_scale(self, in_, scale):

--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -257,10 +257,10 @@ class Transformer:
                 raise ValueError('Mean shape invalid')
             if ms != self.inputs[in_][1:]:
                 print(self.inputs[in_])
-    		 in_shape = self.inputs[in_][1:]
-    		 m_min, m_max = mean.min(), mean.max()
-    		 normal_mean = (mean - m_min) / (m_max - m_min)
-    		 mean = resize_image(normal_mean.transpose((1,2,0)),
+    		    in_shape = self.inputs[in_][1:]
+    		    m_min, m_max = mean.min(), mean.max()
+    		    normal_mean = (mean - m_min) / (m_max - m_min)
+    		    mean = resize_image(normal_mean.transpose((1,2,0)),
                         in_shape[1:]).transpose((2,0,1)) * \
                         (m_max - m_min) + m_min
                 #raise ValueError('Mean shape incompatible with input shape.')

--- a/python/classify.py
+++ b/python/classify.py
@@ -105,6 +105,10 @@ def main(argv):
     mean, channel_swap = None, None
     if args.mean_file:
         mean = np.load(args.mean_file)
+    else: 
+        # channel-wise mean 
+        mean = np.array([104,117,123])
+
     if args.channel_swap:
         channel_swap = [int(s) for s in args.channel_swap.split(',')]
 


### PR DESCRIPTION
Includes the following:
- Changes corresponding to PR #3555
- Changes taken from [SO thread](http://stackoverflow.com/questions/37265197/classify-py-is-not-taking-argument-print-results) to be able to print prediction results. Although the code is modified slightly to support the labels file that contains the folder names, instead of the synset id and the corresponding category text. 
- Changes to use default mean_value when mean_file is not supplied.
